### PR TITLE
Update image as part of Bug Bash 2025

### DIFF
--- a/images/rce_image/Dockerfile
+++ b/images/rce_image/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.14.0a3-slim-bookworm
 
 MAINTAINER Matt Jarvis "matt.jarvis@snyk.io"
 


### PR DESCRIPTION
This pull request includes an update to the `images/rce_image/Dockerfile` file to use a more specific version of the Python base image.

* [`images/rce_image/Dockerfile`](diffhunk://#diff-ea68b9b4f437994fdf6d23ed33243f3e676b81571f4d49b6ecd2d8997ec04893L1-R1): Updated the base image from `python:3` to `python:3.14.0a3-slim-bookworm`.